### PR TITLE
Fix stack smashing bug due to preincrement pointer assign

### DIFF
--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -2754,10 +2754,6 @@ uint8_t Terminal::consumeParamsAndGetCode(int * params, int * paramsCount, bool 
       log('\n');
       #endif
 
-      // reset non specified parameters
-      while (p < params + FABGLIB_MAX_CSI_PARAMS-1)
-        *(++p) = 0;
-
       return c;
     }
 
@@ -2785,6 +2781,10 @@ void Terminal::consumeCSI()
   bool questionMarkFound;
   int params[FABGLIB_MAX_CSI_PARAMS];
   int paramsCount;
+
+  // zero the memory allocated to params
+  memset(params, 0, FABGLIB_MAX_CSI_PARAMS * sizeof(int))
+
   uint8_t c = consumeParamsAndGetCode(params, &paramsCount, &questionMarkFound);
 
   // ESC [ ? ... h
@@ -2813,10 +2813,7 @@ void Terminal::consumeCSI()
     // ESC [ f : HVP, Move cursor to the indicated row, column
     case 'H':
     case 'f':
-      if (paramsCount>=2)
-       setCursorPos(params[1], getAbsoluteRow(params[0]));
-      else
-        setCursorPos(1,1);
+      setCursorPos(params[1], getAbsoluteRow(params[0]));
       break;
 
     // ESC [ g : TBC, Clear one or all tab stops

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -2755,7 +2755,7 @@ uint8_t Terminal::consumeParamsAndGetCode(int * params, int * paramsCount, bool 
       #endif
 
       // reset non specified parameters
-      while (p < params + FABGLIB_MAX_CSI_PARAMS)
+      while (p < params + FABGLIB_MAX_CSI_PARAMS-1)
         *(++p) = 0;
 
       return c;
@@ -2813,7 +2813,10 @@ void Terminal::consumeCSI()
     // ESC [ f : HVP, Move cursor to the indicated row, column
     case 'H':
     case 'f':
-      setCursorPos(params[1], getAbsoluteRow(params[0]));
+      if (paramsCount>=2)
+       setCursorPos(params[1], getAbsoluteRow(params[0]));
+      else
+        setCursorPos(1,1);
       break;
 
     // ESC [ g : TBC, Clear one or all tab stops

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -3415,6 +3415,10 @@ void Terminal::consumeDCS()
   bool questionMarkFound;
   int params[FABGLIB_MAX_CSI_PARAMS];
   int paramsCount;
+
+  // zero the memory allocated to params
+  memset(params, 0, FABGLIB_MAX_CSI_PARAMS * sizeof(int))
+
   uint8_t c = consumeParamsAndGetCode(params, &paramsCount, &questionMarkFound);
 
   // get DCS content up to ST


### PR DESCRIPTION
Also, ESC[H with no parameters should set cursor set 1;1
Perhaps this is broken elsewhere  too?