### PR TITLE
Fix 'undefined references' linker error

### DIFF
--- a/src/dispdrivers/vgadirectcontroller.cpp
+++ b/src/dispdrivers/vgadirectcontroller.cpp
@@ -240,15 +240,15 @@ void VGADirectController::drawEllipse(Size const & size, Rect & updateRect)
 {
 }
 
-void drawArc(Rect const & rect, Rect & updateRect)
+void VGADirectController::drawArc(Rect const & rect, Rect & updateRect)
 {
 }
 
-void fillSegment(Rect const & rect, Rect & updateRect)
+void VGADirectController::fillSegment(Rect const & rect, Rect & updateRect)
 {
 }
 
-void fillSector(Rect const & rect, Rect & updateRect)
+void VGADirectController::fillSector(Rect const & rect, Rect & updateRect)
 {
 }
 


### PR DESCRIPTION
Windows compilation of the latest code of fab-agon-emulator fails with linker errors about undefined references to few fabgl::VGADirectController methods (drawArc / fillSegment / fillSector).

Looks like the problem is that those functions are not implemented as proper class members in VGADirectControllers.cpp, but as free functions outside of the class. For whatever reasons, this is not a problem for the Linux build, but on Windows it caused build failures.