### PR TITLE
Fix compilation error on Windows

### DIFF
--- a/src/userspace-platform/fake_fabgl.h
+++ b/src/userspace-platform/fake_fabgl.h
@@ -65,7 +65,7 @@ extern int64_t esp_timer_get_time();
 void digitalWrite(int, int);
 
 // ESP32Tim;
-unsigned long millis();
+uint64_t millis();
 
 // FABGL
 


### PR DESCRIPTION
Windows build fails due to different return types of millis() function in .h and .cpp files.

The exact error is:

userspace-platform/fake_misc.cpp: At global scope: userspace-platform/fake_misc.cpp:25:10: error: ambiguating new declaration of 'uint64_t millis()'
   25 | uint64_t millis() {
      |          ^~~~~~
userspace-platform/fake_fabgl.h:68:15: note: old declaration 'long unsigned int millis()'
   68 | unsigned long millis();
      |               ^~~~~~